### PR TITLE
Create notion of 'plug-n-play' level for plugin store

### DIFF
--- a/new_plugins.json
+++ b/new_plugins.json
@@ -7,6 +7,7 @@
       ],
       "description": "multiple sequence alignment browser plugin for JBrowse 2",
       "location": "https://github.com/GMOD/jbrowse-plugin-msaview",
+      "plug_n_play": 2,
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js",
       "license": "Apache License 2.0",
       "image": "https://raw.githubusercontent.com/GMOD/jbrowse-plugin-list/main/img/msaview-screenshot-fs8.png"
@@ -21,6 +22,7 @@
       ],
       "description": "JBrowse 2 plugin for integrating with GDC resources",
       "location": "https://github.com/GMOD/jbrowse-plugin-gdc",
+      "plug_n_play": 0,
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-gdc/dist/jbrowse-plugin-gdc.umd.production.min.js",
       "license": "MIT",
       "image": "https://raw.githubusercontent.com/GMOD/jbrowse-plugin-list/main/img/gdc-screenshot-fs8.png"
@@ -32,6 +34,7 @@
       ],
       "description": "External JB2 plugin implementing a QuantitativeSequence track for displaying base-resolution models.",
       "location": "https://github.com/GMOD/jbrowse-plugin-quantseq",
+      "plug_n_play": 0,
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-quantseq/dist/jbrowse-plugin-quantseq.umd.production.min.js",
       "license": "Apache License 2.0",
       "image": "https://raw.githubusercontent.com/GMOD/jbrowse-plugin-list/main/img/quantseq-screenshot-fs8.png"
@@ -42,6 +45,7 @@
         "Colin Diesh"
       ],
       "description": "Plugin for displaying GWAS results such as manhattan plot renderings",
+      "plug_n_play": 1,
       "location": "https://github.com/cmdcolin/jbrowse-plugin-gwas",
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-gwas/dist/jbrowse-plugin-gwas.umd.production.min.js",
       "license": "MIT",
@@ -53,6 +57,7 @@
         "Colin Diesh"
       ],
       "description": "A JBrowse 2 plugin for accessing the UCSC API",
+      "plug_n_play": 0,
       "location": "https://github.com/cmdcolin/jbrowse-plugin-ucsc-api",
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-ucsc/dist/jbrowse-plugin-ucsc.umd.production.min.js",
       "license": "MIT",
@@ -64,6 +69,7 @@
         "Colin Diesh"
       ],
       "description": "Adapts to APIs like mygene.info to get super rich gene annotations",
+      "plug_n_play": 2,
       "location": "https://github.com/cmdcolin/jbrowse-plugin-biothings-api",
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-biothings/dist/jbrowse-plugin-biothings.umd.production.min.js",
       "license": "MIT",
@@ -77,6 +83,7 @@
       ],
       "description": "JBrowse 2 plugin for rendering ideograms",
       "location": "https://github.com/cmdcolin/jbrowse-plugin-ideogram",
+      "plug_n_play": 1,
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-ideogram/dist/jbrowse-plugin-ideogram.umd.production.min.js",
       "license": "Apache License 2.0",
       "image": "https://raw.githubusercontent.com/GMOD/jbrowse-plugin-list/main/img/ideogram-screenshot-fs8.png"
@@ -87,6 +94,7 @@
         "Colin Diesh"
       ],
       "description": "JBrowse 2 plugin for fetching data from the CIVIC clinical interpretation of cancer variants",
+      "plug_n_play": 2,
       "location": "https://github.com/cmdcolin/jbrowse-plugin-civic-api",
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-civic/dist/jbrowseplugincivic.umd.production.min.js",
       "license": "Apache License 2.0",
@@ -98,6 +106,7 @@
         "Caroline Bridge"
       ],
       "description": "JBrowse 2 plugin to integrate resources from the ICGC",
+      "plug_n_play": 2,
       "location": "https://github.com/GMOD/jbrowse-plugin-icgc",
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-icgc/dist/jbrowse-plugin-icgc.umd.production.min.js",
       "license": "Apache License 2.0",
@@ -109,6 +118,7 @@
         "Caroline Bridge"
       ],
       "description": "JBrowse 2 plugin to integrate resources from Reactome",
+      "plug_n_play": 2,
       "location": "https://github.com/GMOD/jbrowse-plugin-reactome",
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-reactome/dist/jbrowse-plugin-reactome.umd.production.min.js",
       "license": "Apache License 2.0",
@@ -120,6 +130,7 @@
         "Caroline Bridge"
       ],
       "description": "JBrowse 2 plugin that adds a linear genome view that can show multiple zoom levels",
+      "plug_n_play": 2,
       "location": "https://github.com/GMOD/jbrowse-plugin-multilevel-linear-view",
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-multilevel-linear-view2/dist/jbrowse-plugin-multilevel-linear-view2.umd.production.min.js",
       "license": "Apache License 2.0",
@@ -130,7 +141,8 @@
       "authors": [
         "Colin Diesh"
       ],
-      "description": "JBrowse 2 plugin that adds ability to connect to hubs from the trackhub registry. Note: only for use with v2.3.0 or greater",
+      "plug_n_play": 2,
+      "description": "JBrowse 2 plugin that adds ability to connect to hubs from the trackhub registry",
       "location": "https://github.com/cmdcolin/jbrowse-plugin-trackhub-registry",
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-trackhub-registry/dist/jbrowse-plugin-trackhub-registry.umd.production.min.js",
       "license": "Apache License 2.0",
@@ -141,6 +153,7 @@
       "authors": [
         "Emilio Righi"
       ],
+      "plug_n_play": 0,
       "description": "JBrowse 2 plugin that adds ability to retrieve sequences from refget API compliant servers",
       "location": "https://github.com/emiliorighi/jbrowse-plugin-refget-api",
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-refget-api/dist/jbrowse-plugin-refget-api.umd.production.min.js",
@@ -152,6 +165,7 @@
         "NAL-i5K"
       ],
       "description": "JBrowse 2 plugin that links out to feature page based on dbxref",
+      "plug_n_play": 0,
       "location": "https://github.com/NAL-i5K/jbrowse-plugin-linkout",
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-linkout/dist/jbrowse-plugin-linkout.umd.production.min.js",
       "license": "Apache License 2.0",
@@ -162,6 +176,7 @@
       "authors": [
         "Colin Diesh"
       ],
+      "plug_n_play": 1,
       "description": "View multiple alignment format (MAF) files as tracks",
       "location": "https://github.com/cmdcolin/jbrowse-plugin-mafviewer",
       "license": "MIT",
@@ -178,6 +193,17 @@
       "license": "MIT",
       "url": "https://jbrowse.org/plugins/jbrowse-plugin-protein3d/dist/jbrowse-plugin-protein3d.umd.production.min.js",
       "image": "https://raw.githubusercontent.com/GMOD/jbrowse-plugin-list/main/img/protein3d-fs8.png"
+    },
+    {
+      "name": "Hubs",
+      "authors": [
+        "Colin Diesh"
+      ],
+      "description": "Automatically load jbrowse hubs as a connection",
+      "plug_n_play": 0,
+      "location": "https://github.com/cmdcolin/jbrowse-plugin-hubs",
+      "license": "MIT",
+      "url": "https://jbrowse.org/plugins/@cmdcolin/jbrowse-plugin-hubs/dist/jbrowse-plugin-hubs.umd.production.min.js"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "download": "node download-plugins.ts",
     "generate": "node generate-plugins.ts",
-    "sync": "aws s3 sync dist s3://jbrowse.org/plugins/ && aws s3 cp new_plugins.json s3://jbrowse.org/plugin-store/plugins.json",
+    "sync": "aws s3 sync dist s3://jbrowse.org/plugins/ && aws s3 cp new_plugins.json s3://jbrowse.org/plugin-store/plugins2.json",
     "deploy": "yarn download && yarn generate && yarn sync",
     "postdeploy": "AWS_PAGER=\"\" aws cloudfront create-invalidation --distribution-id E12EBG02P68TDO --paths \"/plugins/*\""
   },

--- a/plugins.json
+++ b/plugins.json
@@ -5,6 +5,7 @@
       "authors": ["Colin Diesh"],
       "description": "multiple sequence alignment browser plugin for JBrowse 2",
       "location": "https://github.com/GMOD/jbrowse-plugin-msaview",
+      "plug_n_play": 2,
       "url": "https://unpkg.com/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js",
       "license": "Apache License 2.0",
       "image": "https://raw.githubusercontent.com/GMOD/jbrowse-plugin-list/main/img/msaview-screenshot-fs8.png"
@@ -19,6 +20,7 @@
       ],
       "description": "JBrowse 2 plugin for integrating with GDC resources",
       "location": "https://github.com/GMOD/jbrowse-plugin-gdc",
+      "plug_n_play": 0,
       "url": "https://unpkg.com/jbrowse-plugin-gdc/dist/jbrowse-plugin-gdc.umd.production.min.js",
       "license": "MIT",
       "image": "https://raw.githubusercontent.com/GMOD/jbrowse-plugin-list/main/img/gdc-screenshot-fs8.png"
@@ -28,6 +30,7 @@
       "authors": ["Elliot Hershberg"],
       "description": "External JB2 plugin implementing a QuantitativeSequence track for displaying base-resolution models.",
       "location": "https://github.com/GMOD/jbrowse-plugin-quantseq",
+      "plug_n_play": 0,
       "url": "https://unpkg.com/jbrowse-plugin-quantseq/dist/jbrowse-plugin-quantseq.umd.production.min.js",
       "license": "Apache License 2.0",
       "image": "https://raw.githubusercontent.com/GMOD/jbrowse-plugin-list/main/img/quantseq-screenshot-fs8.png"
@@ -36,6 +39,7 @@
       "name": "GWAS",
       "authors": ["Colin Diesh"],
       "description": "Plugin for displaying GWAS results such as manhattan plot renderings",
+      "plug_n_play": 1,
       "location": "https://github.com/cmdcolin/jbrowse-plugin-gwas",
       "url": "https://unpkg.com/jbrowse-plugin-gwas/dist/jbrowse-plugin-gwas.umd.production.min.js",
       "license": "MIT",
@@ -45,6 +49,7 @@
       "name": "UCSC",
       "authors": ["Colin Diesh"],
       "description": "A JBrowse 2 plugin for accessing the UCSC API",
+      "plug_n_play": 0,
       "location": "https://github.com/cmdcolin/jbrowse-plugin-ucsc-api",
       "url": "https://unpkg.com/jbrowse-plugin-ucsc/dist/jbrowse-plugin-ucsc.umd.production.min.js",
       "license": "MIT",
@@ -54,6 +59,7 @@
       "name": "Biothings",
       "authors": ["Colin Diesh"],
       "description": "Adapts to APIs like mygene.info to get super rich gene annotations",
+      "plug_n_play": 2,
       "location": "https://github.com/cmdcolin/jbrowse-plugin-biothings-api",
       "url": "https://unpkg.com/jbrowse-plugin-biothings/dist/jbrowse-plugin-biothings.umd.production.min.js",
       "license": "MIT",
@@ -64,6 +70,7 @@
       "authors": ["Colin Diesh", "Caroline Bridge"],
       "description": "JBrowse 2 plugin for rendering ideograms",
       "location": "https://github.com/cmdcolin/jbrowse-plugin-ideogram",
+      "plug_n_play": 1,
       "url": "https://unpkg.com/jbrowse-plugin-ideogram/dist/jbrowse-plugin-ideogram.umd.production.min.js",
       "license": "Apache License 2.0",
       "image": "https://raw.githubusercontent.com/GMOD/jbrowse-plugin-list/main/img/ideogram-screenshot-fs8.png"
@@ -72,6 +79,7 @@
       "name": "CIVIC",
       "authors": ["Colin Diesh"],
       "description": "JBrowse 2 plugin for fetching data from the CIVIC clinical interpretation of cancer variants",
+      "plug_n_play": 2,
       "location": "https://github.com/cmdcolin/jbrowse-plugin-civic-api",
       "url": "https://unpkg.com/jbrowse-plugin-civic/dist/jbrowseplugincivic.umd.production.min.js",
       "license": "Apache License 2.0",
@@ -81,6 +89,7 @@
       "name": "ICGC",
       "authors": ["Caroline Bridge"],
       "description": "JBrowse 2 plugin to integrate resources from the ICGC",
+      "plug_n_play": 2,
       "location": "https://github.com/GMOD/jbrowse-plugin-icgc",
       "url": "https://unpkg.com/jbrowse-plugin-icgc/dist/jbrowse-plugin-icgc.umd.production.min.js",
       "license": "Apache License 2.0",
@@ -90,6 +99,7 @@
       "name": "Reactome",
       "authors": ["Caroline Bridge"],
       "description": "JBrowse 2 plugin to integrate resources from Reactome",
+      "plug_n_play": 2,
       "location": "https://github.com/GMOD/jbrowse-plugin-reactome",
       "url": "https://unpkg.com/jbrowse-plugin-reactome/dist/jbrowse-plugin-reactome.umd.production.min.js",
       "license": "Apache License 2.0",
@@ -99,6 +109,7 @@
       "name": "MultilevelLinearView",
       "authors": ["Caroline Bridge"],
       "description": "JBrowse 2 plugin that adds a linear genome view that can show multiple zoom levels",
+      "plug_n_play": 2,
       "location": "https://github.com/GMOD/jbrowse-plugin-multilevel-linear-view",
       "url": "https://unpkg.com/jbrowse-plugin-multilevel-linear-view2/dist/jbrowse-plugin-multilevel-linear-view2.umd.production.min.js",
       "license": "Apache License 2.0",
@@ -107,7 +118,8 @@
     {
       "name": "TrackHubRegistry",
       "authors": ["Colin Diesh"],
-      "description": "JBrowse 2 plugin that adds ability to connect to hubs from the trackhub registry. Note: only for use with v2.3.0 or greater",
+      "plug_n_play": 2,
+      "description": "JBrowse 2 plugin that adds ability to connect to hubs from the trackhub registry",
       "location": "https://github.com/cmdcolin/jbrowse-plugin-trackhub-registry",
       "url": "https://unpkg.com/jbrowse-plugin-trackhub-registry/dist/jbrowse-plugin-trackhub-registry.umd.production.min.js",
       "license": "Apache License 2.0",
@@ -116,6 +128,7 @@
     {
       "name": "RefGet",
       "authors": ["Emilio Righi"],
+      "plug_n_play": 0,
       "description": "JBrowse 2 plugin that adds ability to retrieve sequences from refget API compliant servers",
       "location": "https://github.com/emiliorighi/jbrowse-plugin-refget-api",
       "url": "https://unpkg.com/jbrowse-plugin-refget-api/dist/jbrowse-plugin-refget-api.umd.production.min.js",
@@ -125,6 +138,7 @@
       "name": "Linkout",
       "authors": ["NAL-i5K"],
       "description": "JBrowse 2 plugin that links out to feature page based on dbxref",
+      "plug_n_play": 0,
       "location": "https://github.com/NAL-i5K/jbrowse-plugin-linkout",
       "url": "https://unpkg.com/jbrowse-plugin-linkout/dist/jbrowse-plugin-linkout.umd.production.min.js",
       "license": "Apache License 2.0",
@@ -133,6 +147,7 @@
     {
       "name": "MafViewer",
       "authors": ["Colin Diesh"],
+      "plug_n_play": 1,
       "description": "View multiple alignment format (MAF) files as tracks",
       "location": "https://github.com/cmdcolin/jbrowse-plugin-mafviewer",
       "license": "MIT",
@@ -147,6 +162,15 @@
       "license": "MIT",
       "url": "https://unpkg.com/jbrowse-plugin-protein3d/dist/jbrowse-plugin-protein3d.umd.production.min.js",
       "image": "https://raw.githubusercontent.com/GMOD/jbrowse-plugin-list/main/img/protein3d-fs8.png"
+    },
+    {
+      "name": "Hubs",
+      "authors": ["Colin Diesh"],
+      "description": "Automatically load jbrowse hubs as a connection",
+      "plug_n_play": 0,
+      "location": "https://github.com/cmdcolin/jbrowse-plugin-hubs",
+      "license": "MIT",
+      "url": "https://unpkg.com/@cmdcolin/jbrowse-plugin-hubs/dist/jbrowse-plugin-hubs.umd.production.min.js"
     }
   ]
 }


### PR DESCRIPTION
Many plugins will not be effectively very useful when installed. That might be a subjective statement but this PR tries to make this more clear to the user by adding a 'plug_n_play' field to the plugins.json that conveys which plugins might be useful when installing into a users session

Higher levels have more "plug-n-play" capability: they can be used without advanced configuration for example
