### PR TITLE
Create PR to approve plugin updates in cron job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,16 @@ name: Deploy to S3
 on:
   schedule:
     - cron: '0 0 * * *' # Runs daily at midnight
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  deploy:
+  update-plugins:
+    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
 
     steps:
@@ -20,8 +27,36 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Deploy to S3
-        run: yarn deploy
+      - name: Update plugins
+        run: yarn update
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: 'Update plugins'
+          title: 'Update plugins'
+          body: 'Automated plugin updates from npm registry'
+          branch: update-plugins
+          delete-branch: true
+
+  deploy:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Upload to S3
+        run: yarn upload
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This is a middle-man to YOLO'ing any plugin updates from NPM to our S3 bucket (which we use now instead of the unpkg NPM for hosting plugin code)

The PR allows us to approve a PR first before updating the S3 bucket